### PR TITLE
include automation platform yarn.loc builds

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -69,6 +69,8 @@ class Dashboard extends React.Component
               'platform-complete': { branch: 'snapshot' },
               'platform-core': { branch: 'snapshot' },
               'platform-erm': { branch: 'snapshot' },
+              'build-platform-complete-snapshot': { jobRoot: 'Automation', branch: 'snapshot' },
+              'build-platform-core-snapshot': { jobRoot: 'Automation', branch: 'snapshot' },
             }
           };
     }
@@ -84,7 +86,7 @@ class Dashboard extends React.Component
         const repos = this.state[repoGroup];
         Object.keys(repos).forEach(key => {
             if (typeof repos[key].stable === "undefined") {
-                fetch(`proxy.php?module=${key}&branch=${repos[key].branch ? repos[key].branch : 'master' }`)
+                fetch(`proxy.php?module=${key}&branch=${repos[key].branch ? repos[key].branch : 'master' }&jobRoot=${repos[key].jobRoot ? repos[key].jobRoot : ''}`)
                 .then(response => response.json())
                 .then(data => {
                     if (data.lastCompletedBuild.number == data.lastSuccessfulBuild.number) {


### PR DESCRIPTION
Include the jobs that build platform-complete and platform-core and save
their `yarn.lock` files when they are successful. In fact, these are
probably the platform jobs we actually care about, not the the plain old
platform-* builds listed previously because those simply use the
`yarn.lock` files generated here, i.e. they _don't actually build the
platform_.