### PR TITLE
elegantly handle jenkins build failure

### DIFF
--- a/release
+++ b/release
@@ -172,13 +172,13 @@ JENKINS_AUTH_HEADER=`printf $JENKINS_USER:$JENKINS_PASS | base64`
 
 echo "triggering Jenkins build..."
 
-if [! curl -s -X POST https://jenkins-aws.indexdata.com/job/folio-org/job/$REPO/view/tags/job/$GHTAG/build \
-    --header "Authorization: Basic $JENKINS_AUTH_HEADER" ]; then
-    echo GitHub hasn't pushed the tag to Jenkins yet. Wait a few seconds, then visit
-    echo
-    echo    https://jenkins-aws.indexdata.com/job/folio-org/job/$REPO/view/tags/job/$GHTAG
-    echo
-    echo sign in, and click the 'Build Now' button to build your release.
+if curl -i -s -X POST https://jenkins-aws.indexdata.com/job/folio-org/job/$REPO/view/tags/job/$GHTAG/build \
+    --header "Authorization: Basic $JENKINS_AUTH_HEADER" | grep -q 'HTTP/1.1 404 Not Found'; then
+    echo "GitHub hasn't pushed the tag to Jenkins yet. Wait a few seconds, then visit"
+    echo ""
+    printf "    %s\n" https://jenkins-aws.indexdata.com/job/folio-org/job/$REPO/view/tags/job/$GHTAG
+    echo ""
+    echo "sign in, and click the 'Build Now' button to build your release."
 fi
 
 echo 'done!'


### PR DESCRIPTION
When the Jenkins build fails because the tag can't be found (i.e.
because GitHub hasn't had time to push it to Jenkins yet), show a link
to the build page.