### PR TITLE
push branch AND tags

### DIFF
--- a/release
+++ b/release
@@ -140,6 +140,7 @@ JIRA_AUTH_HEADER=`printf "${JIRA_USER}:${JIRA_PASS}" | base64`
 
 echo "tagging release $GHTAG and pushing it to GitHub..."
 git tag $GHTAG
+git push
 git push --tags -q
 
 # update fix-version for each ticket


### PR DESCRIPTION
Previously, only `git push --tags` was invoked after tagging the release
commit. Now, `git push; git push --tags` is invoked in order to push all
changes that are present on the branch, as well as the commit the tag
points to.