### PR TITLE
Replace obsolete <tt> with <code> in index.html

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -46,7 +46,7 @@
 
   </head>
   <body>
-    <h1>GitHub <tt>master</tt> build status</h1>
+    <h1>GitHub <code>master</code> build status</h1>
     <div id="dashboard" />
 
     <script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>


### PR DESCRIPTION
See `<tt>` deprecation, https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt.

Hi Zak, cool project!