### PR TITLE
rename to jspam, add shell exec line

### DIFF
--- a/jspam/jspam.js
+++ b/jspam/jspam.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const { exec } = require("child_process");
 const yargs = require('yargs/yargs')
 const { hideBin } = require('yargs/helpers')

--- a/jspam/package.json
+++ b/jspam/package.json
@@ -2,7 +2,7 @@
   "name": "jspam",
   "version": "1.0.0",
   "description": "create jira tickets in many projects",
-  "main": "index.js",
+  "main": "jspam.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Add `!#/usr/bin/env node` to make the script directly executable.

Rename from `index.js` to `jspam.js` to ever so slightly more clearly
indicate what this does when you are executing at the CLI.