### PR TITLE
release jira versions

### DIFF
--- a/release
+++ b/release
@@ -171,4 +171,16 @@ for ticket in $TICKETS; do
     if [ -f $ticket ]; then rm $ticket; fi;
 done;
 
+# mark jira version as "released"
+echo "Releasing Jira version $TAG"
+RELEASE_DATE=`date +%Y-%m-%d`
+JIRA_VERSION=`echo $VERSIONS | jq -c ".[] | select(.name == \"$TAG\") | .released = true | .releaseDate = \"$RELEASE_DATE\" | del(.userReleaseDate) "  | sed 's/\"/\\"/g'`
+JIRA_VERSION_URL=`echo $VERSIONS | jq -c ".[] | select(.name == \"$TAG\") | .self"`
+curl -s --location \
+    -X PUT $JIRA_VERSION_URL \
+    -H "content-type: application/json" \
+    -H "Authorization: Basic $JIRA_AUTH_HEADER" \
+    -d "$JIRA_VERSION" > /dev/null
+
+
 echo 'done!'


### PR DESCRIPTION
Mark Jira versions as released once all other work is done. This is
slightly fraught as it's possible the GA build, which happens
asynchronously, can fail, but it feels like The Right Thing given that
the firm expectation that even if the current GA build fails, a
subsequent one will succeed.