### PR TITLE
ticket labels attribute must always be an array

### DIFF
--- a/jspam/jspam.js
+++ b/jspam/jspam.js
@@ -450,7 +450,7 @@ class JSpam {
                 description: this.argv.description,
                 project: pmap[d],
                 epic: this.argv.epic,
-                labels: this.argv.label,
+                labels: Array.isArray(this.argv.label) ? this.argv.label : [this.argv.label],
                 team: t,
                 cc: cc,
               })


### PR DESCRIPTION
The `labels` attribute of a ticket must be an array, and now it always is, regardless of whether one label or multiple labels are attached.